### PR TITLE
Do not decrement shots if no shot is left

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,8 +106,10 @@ impl Shots {
         }
     }
     pub fn fire(&mut self) {
-        self.gone += 1;
-        self.left -= 1;
+        if self.left > 0 {
+            self.gone += 1;
+            self.left -= 1;
+        }
     }
 }
 


### PR DESCRIPTION
That way the player can still shoot more apples, but the game will end
as soon as the 10th apple touches ground.